### PR TITLE
Fix of ImgTagTransformPass::setResponsiveImgHeightAndWidth()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,19 @@
 {
-    "name": "lullabot/amp",
+    "name": "GuideToIceland/amp",
     "description": "A set of useful classes and utilities to convert html to AMP html (See https://www.ampproject.org/)",
     "authors": [
         {
             "name": "Sidharth Kshatriya",
             "email": "sid.kshatriya@gmail.com"
+        },
+        {
+            "name": "Aurelien Gerbore",
+            "email": "agerbore@gmail.com"
         }
     ],
     "license": "Apache-2.0",
-    "keywords": ["Drupal", "AMP", "mobile"],
-    "homepage": "https://github.com/Lullabot/amp-library",
+    "keywords": ["AMP", "mobile"],
+    "homepage": "https://github.com/GuideToIceland/amp-library",
     "require" : {
         "php" : ">=5.5.0",
         "querypath/QueryPath": ">=3.0.4",

--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -217,7 +217,7 @@ class ImgTagTransformPass extends BasePass
         $wcss = new CssLengthAndUnit($el->attr('width'), false);
         $hcss = new CssLengthAndUnit($el->attr('height'), false);
 
-        if ($wcss->is_set && $wcss->is_valid && $wcss->is_set && $wcss->is_valid && $wcss->unit == $hcss->unit) {
+        if ($wcss->is_set && $wcss->is_valid && $hcss->is_set && $hcss->is_valid && $wcss->unit == $hcss->unit) {
             return true;
         }
 

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -13,10 +13,10 @@
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" layout="responsive" width="625" height="480"></amp-img>
 
 <!-- since only width exists, overwrite with height and width from original image -->
-<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="500"></amp-img>
+<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>
 
 <!-- since height is illegal, overwrite with height and width from original image -->
-<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625"></amp-img>
+<amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>
 
 <!-- since units are inconsistent, overwrite with height+width from original image -->
 <amp-img layout="responsive" src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480"></amp-img>

--- a/tests/test-data/full-html/mandatory_dimensions.html
+++ b/tests/test-data/full-html/mandatory_dimensions.html
@@ -111,7 +111,7 @@
     <amp-img src="img" layout="container" width="42" height="42"></amp-img>
     <amp-img src="img"></amp-img>
 
-    <!-- Layout of responsive/fixed without width/height -->
+    <!-- Layout of responsive/fixed without width/height - This should all fail -->
     <amp-img src="img" layout="responsive"></amp-img>
     <amp-img src="img" layout="fixed"></amp-img>
     <amp-img src="img" layout="responsive" width="42"></amp-img>

--- a/tests/test-data/full-html/mandatory_dimensions.html.out
+++ b/tests/test-data/full-html/mandatory_dimensions.html.out
@@ -117,7 +117,7 @@
     <amp-img src="img" width="42" height="42" layout="responsive"></amp-img>
     <amp-img src="img" layout="responsive"></amp-img>
 
-    <!-- Layout of responsive/fixed without width/height -->
+    <!-- Layout of responsive/fixed without width/height - This should all fail -->
     <amp-img src="img" layout="responsive"></amp-img>
     <amp-img src="img" layout="fixed"></amp-img>
     <amp-img src="img" layout="responsive" width="42"></amp-img>
@@ -272,7 +272,7 @@ Line 110:     <amp-img src="img" layout="container"></amp-img>
 Line 111:     <amp-img src="img" layout="container" width="42" height="42"></amp-img>
 Line 112:     <amp-img src="img"></amp-img>
 Line 113: 
-Line 114:     <!-- Layout of responsive/fixed without width/height -->
+Line 114:     <!-- Layout of responsive/fixed without width/height - This should all fail -->
 Line 115:     <amp-img src="img" layout="responsive"></amp-img>
 Line 116:     <amp-img src="img" layout="fixed"></amp-img>
 Line 117:     <amp-img src="img" layout="responsive" width="42"></amp-img>
@@ -343,7 +343,6 @@ FAIL
 <amp-img src="img" layout="responsive" width="42"> on line 117
 - The mandatory attribute 'height' is missing in tag 'amp-img'.
    [code: MANDATORY_ATTR_MISSING  category: AMP_LAYOUT_PROBLEM see: https://www.ampproject.org/docs/reference/amp-img.html]
-   ACTION TAKEN: amp-img tried to fix problems with amp-img by trying to fetch height, width from image directly and/or setting layout to responsive
 
 <amp-img src="img" layout="fixed" height="42"> on line 118
 - The mandatory attribute 'width' is missing in tag 'amp-img'.


### PR DESCRIPTION
Fix  ImgTagTransformPass::setResponsiveImgHeightAndWidth()

was returning true even if  the CssLengthAndUnit for height was not valid